### PR TITLE
feat: add calibration and popover functionality

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -1,42 +1,89 @@
 <template>
   <form action="#" method="get">
+    <h4>Vue Range Slider</h4>
     <range-slider
-      class="slider"
+      class="slider slider-small"
       v-model="value"
       :name="name"
       :min="min"
       :max="max"
       :step="step"
-      :disabled="disabled"></range-slider>
+      :disabled="disabled"
+      :no-popover="true"
+      :no-calibration="true">
+    </range-slider>
+    
+    <h4>Vue Range Slider with 5-step calibration</h4>
+    <range-slider
+      class="slider slider-large"
+      v-model="value"
+      :name="name"
+      :min="min"
+      :max="max"
+      :step="step"
+      :disabled="disabled"
+      :no-popover="true"
+      :calibration-count="5">
+    </range-slider>
+    
+    <h4>Vue Range Slider with 10-step calibration</h4>
+    <range-slider
+      class="slider slider-large"
+      v-model="value"
+      :name="name"
+      :min="min"
+      :max="max"
+      :step="step"
+      :disabled="disabled"
+      :no-popover="true"
+      :calibration-count="10">
+    </range-slider>
+    
+    <h4>Vue Range Slider with popover and calibration</h4>
+    <range-slider
+      class="slider slider-large"
+      v-model="value"
+      :name="name"
+      :min="min"
+      :max="max"
+      :step="step"
+      :disabled="disabled"
+      :no-calibration="true">
+      <template slot="popover">
+        <h4>${{Number(value || 0).toLocaleString('en')}}</h4>
+      </template>
+    </range-slider>
 
-    <div>
-      name
-      <input class="name" type="text" v-model="name">
-    </div>
+    <div class="container">
+      <div>
+        name
+        <input class="name" type="text" v-model="name">
+      </div>
 
-    <div>
-      value
-      <input class="value" type="number" v-model="value">
-    </div>
+      <div>
+        value
+        <input class="value" type="number" v-model="value">
+      </div>
 
-    <div>
-      min
-      <input class="min" type="number" v-model="min">
-    </div>
+      <div>
+        min
+        <input class="min" type="number" v-model="min">
+      </div>
 
-    <div>
-      max
-      <input class="max" type="number" v-model="max">
-    </div>
+      <div>
+        max
+        <input class="max" type="number" v-model="max">
+      </div>
 
-    <div>
-      step
-      <input class="step" type="number" v-model="step">
-    </div>
+      <div>
+        step
+        <input class="step" type="number" v-model="step">
+      </div>
 
-    <div>
-      disabled
-      <input class="disabled" type="checkbox" v-model="disabled">
+      <div>
+        disabled
+        <input class="disabled" type="checkbox" v-model="disabled">
+      </div>
     </div>
   </form>
 </template>
@@ -50,7 +97,7 @@ export default {
       name: null,
       value: undefined,
       min: 0,
-      max: 100,
+      max: 2000,
       step: 1,
       disabled: false
     }
@@ -60,3 +107,23 @@ export default {
   }
 }
 </script>
+
+<style>
+  .slider {
+    width: 100%;
+  }
+
+  .slider-small {
+    margin-bottom: 20px;
+  }
+
+  .slider-large {
+    margin-bottom: 80px;
+  }
+
+  .container {
+    margin-left: 20px;
+    margin-right: 20px;
+    margin-top: 100px;
+  }
+</style>

--- a/src/RangeSlider.vue
+++ b/src/RangeSlider.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <span class="range-slider" :class="{ disabled }">
+  <span class="range-slider" ref="elem" @mousedown="shiftKnob" :class="{ disabled }">
     <drag-helper
       target-selector=".range-slider-knob"
       v-bind:disabled="disabled"
@@ -11,6 +11,9 @@
         <span class="range-slider-fill" :style="{ width: valuePercent + '%' }"></span>
         <span class="range-slider-knob" :style="{ left: valuePercent + '%' }">
           <slot name="knob"></slot>
+          <popover>
+            <slot name="popover"></slot>
+          </popover>
         </span>
       </span>
     </drag-helper>
@@ -22,6 +25,7 @@
 
 import DragHelper from './DragHelper'
 import { round } from './utils'
+import popover from './popover.vue'
 
 export default {
   props: {
@@ -125,11 +129,32 @@ export default {
 
     round (value: number): number {
       return round(value, this._min, this._max, this._step)
+    },
+
+    shiftKnob (e: Event) {
+
+      if (['range-slider', 'range-slider-inner', 'range-slider-fill'].some(c => e.path[0].classList.contains(c))) {
+        const x = e.pageX - this.$refs.elem.offsetLeft
+      
+        const percent = Math.floor(x / this.$refs.elem.offsetWidth * 100)
+
+        this.actualValue = this.round((percent / 100 * (this._max - this._min)) + this._min)
+
+        this.emitEvent(this.actualValue, true)
+
+        console.log(e)
+      }
+      
     }
   },
 
   components: {
-    DragHelper
+    DragHelper,
+    popover
+  },
+
+  mounted () {
+    
   }
 }
 </script>

--- a/src/RangeSlider.vue
+++ b/src/RangeSlider.vue
@@ -11,9 +11,15 @@
         <span class="range-slider-fill" :style="{ width: valuePercent + '%' }"></span>
         <span class="range-slider-knob" :style="{ left: valuePercent + '%' }">
           <slot name="knob"></slot>
-          <popover>
+          <popover v-if="!noPopover">
             <slot name="popover"></slot>
           </popover>
+        </span>
+        <span class="range-slider-calibration" v-if="!noCalibration">
+          <span class="calibration-item" v-for="offset in calibrationOffsets" :key="offset" :style="{ left: offset + '%' }">
+            <div>|</div>
+            <span class="calibration-knob">{{(offset / 100 * (_max - _min)) + _min}}</span>
+          </span>
         </span>
       </span>
     </drag-helper>
@@ -46,6 +52,18 @@ export default {
     step: {
       type: [String, Number],
       default: 1
+    },
+    noPopover: {
+      type: Boolean,
+      default: false
+    },
+    noCalibration: {
+      type: Boolean,
+      default: false
+    },
+    calibrationCount: {
+      type: Number,
+      default: 10
     }
   },
 
@@ -85,6 +103,11 @@ export default {
 
     valuePercent () {
       return (this.actualValue - this._min) / (this._max - this._min) * 100
+    },
+
+    calibrationOffsets () {
+      //this can definitely be improved
+      return [0, ...'0'.repeat(this.calibrationCount).split('').map((c, i) => (i + 1))].map(i => i / this.calibrationCount * 100)
     }
   },
 
@@ -224,6 +247,26 @@ $knob-shadow: 1px 1px rgba(0, 0, 0, 0.2) !default;
   box-shadow: $knob-shadow;
   transform: translate(-50%, -50%);
   cursor: pointer;
+}
+
+.range-slider-calibration {
+  display: block;
+  position: absolute;
+  width: 100%;
+  top: 100%;
+  box-sizing: border-box;
+
+  .calibration-item {
+    color: #777;
+    display: inline-block;
+    position: absolute;
+    width: 50px;
+
+    .calibration-knob {
+      position: absolute;
+      left: -30%;
+    }
+  }
 }
 
 .range-slider-hidden {

--- a/src/popover.vue
+++ b/src/popover.vue
@@ -1,0 +1,42 @@
+<template>
+    <div id="popover-default" class="popover-container bottom">
+        <div>
+            <slot></slot>
+        </div>
+    </div>
+</template>
+
+<script>
+    export default {
+        
+    }
+</script>
+
+<style>
+    .popover-container {
+        margin-top: 30px;
+        width: 180px;
+        margin-left: -30px;
+        border: 1px solid #21fb92;
+        padding: 5px;
+    }
+
+    .popover-container::before {
+        content: "";
+        width: 0px;
+        height: 0px;
+        border: 0.8em solid transparent;
+        position: absolute;
+        pointer-events: none;
+    }
+
+    .popover-container.bottom::before {
+        left: -20%;
+        top: 7px;
+        border-bottom: 10px solid #21fb92;
+    }
+
+    .popover {
+        position: relative;
+    }
+</style>


### PR DESCRIPTION
- user can click on the range slider body to change value
- add popover slot so user can determine what text shows under the range slider
  - can be turned off with `no-popover=true` prop
- add calibration so users can see the input values range.
  - includes `calibration-count:Number` prop
  - can be turned off with `no-calibration=true` prop

![image](https://user-images.githubusercontent.com/11996508/36945791-60270782-1fb3-11e8-9f84-f2e63c3c9337.png)
